### PR TITLE
If a 100% change of text in TD breaks the table layout

### DIFF
--- a/htmltreediff/test_html.py
+++ b/htmltreediff/test_html.py
@@ -383,7 +383,7 @@ def test_fix_lists():
               </del>
               <ins>
                 <li>BBB</li>
-              </inst>
+              </ins>
             </ol>
             ''',
             '''
@@ -401,7 +401,7 @@ def test_fix_lists():
               </del>
               <ins>
                 <li class="new">BBB</li>
-              </inst>
+              </ins>
             </ol>
             ''',
             '''
@@ -420,7 +420,7 @@ def test_fix_lists():
                 <li><strong>BBB</strong></li>
               <ins>
                 <li>CCC</li>
-              </inst>
+              </ins>
             </ol>
             ''',
             '''
@@ -443,7 +443,7 @@ def test_fix_lists():
                 <li><strong>BBB</strong></li>
               <ins>
                 <li>CCC</li>
-              </inst>
+              </ins>
             </ol>
             ''',
             '''
@@ -468,7 +468,7 @@ def test_fix_lists():
               </del>
               <ins>
                 <li>CCC</li>
-              </inst>
+              </ins>
             </ol>
             ''',
             '''
@@ -489,7 +489,7 @@ def test_fix_lists():
               </del>
               <ins>
                 <foo>BBB</foo>
-              </inst>
+              </ins>
             </ol>
             ''',
             '''
@@ -499,7 +499,7 @@ def test_fix_lists():
                 </li>
                 <ins>
                     <foo>BBB</foo>
-                </inst>
+                </ins>
             </ol>
             ''',
         ),
@@ -512,7 +512,7 @@ def test_fix_lists():
               </del>
               <ins>
                 BBB
-              </inst>
+              </ins>
             </ol>
             ''',
             '''
@@ -522,7 +522,7 @@ def test_fix_lists():
                 </li>
                 <ins>
                     BBB
-                </inst>
+                </ins>
             </ol>
             ''',
         ),

--- a/htmltreediff/test_html.py
+++ b/htmltreediff/test_html.py
@@ -374,6 +374,158 @@ def test_fix_lists():
             </ol>
             '''
         ),
+        (
+            'LI full content change does not add another LI',
+            '''
+            <ol>
+              <del>
+                <li>AAA</li>
+              </del>
+              <ins>
+                <li>BBB</li>
+              </inst>
+            </ol>
+            ''',
+            '''
+            <ol>
+              <li><del>AAA</del><ins>BBB</ins></li>
+            </ol>
+            '''
+        ),
+        (
+            'LI full content change keeps attrs',
+            '''
+            <ol>
+              <del>
+                <li class="old" id="foo">AAA</li>
+              </del>
+              <ins>
+                <li class="new">BBB</li>
+              </inst>
+            </ol>
+            ''',
+            '''
+            <ol>
+              <li class="new"><del>AAA</del><ins>BBB</ins></li>
+            </ol>
+            '''
+        ),
+        (
+            'LI changes markup internalization fix not done if next tag is not an insert',  # noqa
+            '''
+            <ol>
+              <del>
+                <li>AAA</li>
+              </del>
+                <li><strong>BBB</strong></li>
+              <ins>
+                <li>CCC</li>
+              </inst>
+            </ol>
+            ''',
+            '''
+            <ol>
+                <li class="del-li">
+                    <del>AAA</del>
+                </li>
+                <li><strong>BBB</strong></li>
+                <li><ins>CCC</ins></li>
+            </ol>
+            ''',
+        ),
+        (
+            'LI changes markup internalization fix not done if next tag is not an insert',  # noqa
+            '''
+            <ol>
+              <del>
+                <li>AAA</li>
+              </del>
+                <li><strong>BBB</strong></li>
+              <ins>
+                <li>CCC</li>
+              </inst>
+            </ol>
+            ''',
+            '''
+            <ol>
+                <li class="del-li">
+                    <del>AAA</del>
+                </li>
+                <li><strong>BBB</strong></li>
+                <li><ins>CCC</ins></li>
+            </ol>
+            ''',
+        ),
+        (
+            'LI after del must be ins',
+            '''
+            <ol>
+              <del>
+                <li>AAA</li>
+              </del>
+              <del>
+                <li>BBB</li>
+              </del>
+              <ins>
+                <li>CCC</li>
+              </inst>
+            </ol>
+            ''',
+            '''
+            <ol>
+                <li class="del-li">
+                    <del>AAA</del>
+                </li>
+                <li><del>BBB</del><ins>CCC</ins></li>
+            </ol>
+            ''',
+        ),
+        (
+            'LI changes markup internalization fix not performed if next tags child is not li',  # noqa
+            '''
+            <ol>
+              <del>
+                <li>AAA</li>
+              </del>
+              <ins>
+                <foo>BBB</foo>
+              </inst>
+            </ol>
+            ''',
+            '''
+            <ol>
+                <li class="del-li">
+                    <del>AAA</del>
+                </li>
+                <ins>
+                    <foo>BBB</foo>
+                </inst>
+            </ol>
+            ''',
+        ),
+        (
+            'LI changes markup internalization fix not performed if next tags is text',  # noqa
+            '''
+            <ol>
+              <del>
+                <li>AAA</li>
+              </del>
+              <ins>
+                BBB
+              </inst>
+            </ol>
+            ''',
+            '''
+            <ol>
+                <li class="del-li">
+                    <del>AAA</del>
+                </li>
+                <ins>
+                    BBB
+                </inst>
+            </ol>
+            ''',
+        ),
     ]
     for test_name, changes, fixed_changes in cases:
         changes = collapse(changes)

--- a/htmltreediff/tests.py
+++ b/htmltreediff/tests.py
@@ -821,6 +821,49 @@ test_cases = [  # test case = (old html, new html, inline changes, edit script)
             }),
         ]
     ),
+    (
+        'TD content change does not show TD removal',
+        '''
+        <table>
+            <tbody>
+                <tr>
+                    <td>AAA</td>
+                    <td>BBB</td>
+                </tr>
+            </tbody>
+        </table>
+        ''',
+        collapse('''
+        <table>
+            <tbody>
+                <tr>
+                    <td>ZZZ</td>
+                    <td>BBB</td>
+                </tr>
+            </tbody>
+        </table>
+        '''),
+        collapse('''
+        <table>
+            <tbody>
+                <tr>
+                    <td><del>AAA</del><ins>ZZZ</ins></td>
+                    <td>BBB</td>
+                </tr>
+            </tbody>
+        </table>
+        '''),
+        [  # TODO This may not be correct
+            ('delete', [0, 0, 0, 0], {
+                'node_type': Node.TEXT_NODE,
+                'node_value': u'AAA',
+            }),
+            ('insert', [0, 0, 0, 0], {
+                'node_type': Node.TEXT_NODE,
+                'node_value': u'ZZZ',
+            }),
+        ],
+    ),
 ]
 
 # test cases that should not be run in reverse

--- a/htmltreediff/tests.py
+++ b/htmltreediff/tests.py
@@ -853,12 +853,103 @@ test_cases = [  # test case = (old html, new html, inline changes, edit script)
             </tbody>
         </table>
         '''),
-        [  # TODO This may not be correct
-            ('delete', [0, 0, 0, 0], {
+        [  # The result of this will be fixed by fix_tables
+            ('delete', [0, 0, 0, 0, 0], {
                 'node_type': Node.TEXT_NODE,
                 'node_value': u'AAA',
             }),
+            ('delete', [0, 0, 0, 0], {
+                'node_type': Node.ELEMENT_NODE,
+                'node_name': u'td',
+            }),
             ('insert', [0, 0, 0, 0], {
+                'node_type': Node.ELEMENT_NODE,
+                'node_name': u'td',
+            }),
+            ('insert', [0, 0, 0, 0, 0], {
+                'node_type': Node.TEXT_NODE,
+                'node_value': u'ZZZ',
+            }),
+        ],
+    ),
+    (
+        'LI content change does not show LI removal',
+        '''
+        <ol>
+            <li>AAA</li>
+            <li>BBB</li>
+        </ol>
+        ''',
+        collapse('''
+        <ol>
+            <li>ZZZ</li>
+            <li>BBB</li>
+        </ol>
+        '''),
+        collapse('''
+        <ol>
+            <li><del>AAA</del><ins>ZZZ</ins></li>
+            <li>BBB</li>
+        </ol>
+        '''),
+        [  # The result of this will be fixed by fix_lists
+            ('delete', [0, 0, 0], {
+                'node_type': Node.TEXT_NODE,
+                'node_value': u'AAA',
+            }),
+            ('delete', [0, 0], {
+                'node_type': Node.ELEMENT_NODE,
+                'node_name': u'li',
+            }),
+            ('insert', [0, 0], {
+                'node_type': Node.ELEMENT_NODE,
+                'node_name': u'li',
+            }),
+            ('insert', [0, 0, 0], {
+                'node_type': Node.TEXT_NODE,
+                'node_value': u'ZZZ',
+            }),
+        ],
+    ),
+    (
+        'Nested LI content change does not show LI removal',
+        collapse('''
+        <ol>
+            <li>AAA<ol>
+                    <li>BBB</li>
+                    <li>CCC</li>
+                </ol>
+            </li>
+            <li>DDD</li>
+        </ol>
+        '''),
+        collapse('''
+        <ol>
+            <li>ZZZ<ol>
+                    <li>BBB</li>
+                    <li>CCC</li>
+                </ol>
+            </li>
+            <li>DDD</li>
+        </ol>
+        '''),
+        collapse('''
+        <ol>
+            <li><del>AAA</del><ins>ZZZ</ins>
+                <ol>
+                    <li>BBB</li>
+                    <li>CCC</li>
+                </ol>
+            </li>
+            <li>DDD</li>
+        </ol>
+        '''),
+        [
+            ('delete', [0, 0, 0], {
+                'node_type': Node.TEXT_NODE,
+                'node_value': u'AAA',
+            }),
+            ('insert', [0, 0, 0], {
                 'node_type': Node.TEXT_NODE,
                 'node_value': u'ZZZ',
             }),
@@ -1037,6 +1128,60 @@ insane_test_cases = [
     # '<ul><li>X</li></ul>',
     # '<ul><li>X</li></ul>',
     # ),
+    (
+        'LI full content change keeps attrs',
+        collapse('''
+        <ol>
+            <li id="foo" class="old">AAA</li>
+            <li>BBB</li>
+        </ol>
+        '''),
+        collapse('''
+        <ol>
+            <li class="new">ZZZ</li>
+            <li>BBB</li>
+        </ol>
+        '''),
+        collapse('''
+        <ol>
+            <li class="new"><del>AAA</del><ins>ZZZ</ins></li>
+            <li>BBB</li>
+        </ol>
+        '''),
+    ),
+    (
+        'TD content change does not show TD removal with THs',
+        collapse('''
+        <table>
+            <tbody>
+                <tr>
+                    <td>AAA</td>
+                    <td>BBB</td>
+                </tr>
+            </tbody>
+        </table>
+        '''),
+        collapse('''
+        <table>
+            <tbody>
+                <tr>
+                    <th>ZZZ</th>
+                    <td>BBB</td>
+                </tr>
+            </tbody>
+        </table>
+        '''),
+        collapse('''
+        <table>
+            <tbody>
+                <tr>
+                    <th><del>AAA</del><ins>ZZZ</ins></th>
+                    <td>BBB</td>
+                </tr>
+            </tbody>
+        </table>
+        '''),
+    ),
 ]
 
 # Assemble test cases

--- a/htmltreediff/util.py
+++ b/htmltreediff/util.py
@@ -431,6 +431,17 @@ def wrap(node, tag):
     return wrap_node
 
 
+def wrap_nodes(nodes, tag):
+    """Just like wrap, but for more than one tag at a time"""
+    wrap_node = nodes[0].ownerDocument.createElement(tag)
+    parent = nodes[0].parentNode
+    if parent:
+        parent.replaceChild(wrap_node, nodes[0])
+    for node in nodes:
+        wrap_node.appendChild(node)
+    return wrap_node
+
+
 def wrap_inner(node, tag):
     """Wrap the given tag around the contents of a node."""
     children = list(node.childNodes)

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,3 @@
 coverage==3.7
 nose==1.3
-flake8=<3
+flake8<=3

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,3 +1,3 @@
 coverage==3.7
 nose==1.3
-flake8==2
+flake8=<3


### PR DESCRIPTION
Instead of the text being inserted/deleted the entire TD is inserted/deleted (resulting in an extra column)