### PR TITLE
Add a class to empty del tags

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,14 @@
+__pycache__/
+.vscode
 *.pyc
+*~
+.DS\_Store
+.env
+.direnv
 .coverage
 
 build
 dist
 *.egg-info
 .tox
+.workflow

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ __pycache__/
 
 build
 dist
+*.whl
 *.egg-info
 .tox
 .workflow

--- a/htmltreediff/changes.py
+++ b/htmltreediff/changes.py
@@ -65,7 +65,7 @@ def add_changes_markup(dom, ins_nodes, del_nodes):
     # Perform post-processing and cleanup.
     remove_nesting(dom, 'del')
     remove_nesting(dom, 'ins')
-    sort_del_before_ins(dom)
+    sort_nodes(dom)
     merge_adjacent(dom, 'del')
     merge_adjacent(dom, 'ins')
 
@@ -85,7 +85,7 @@ def remove_nesting(dom, tag_name):
                 break
 
 
-def sort_nodes(dom, cmp_func):
+def sort_nodes(dom, cmp_func=node_compare):
     """
     Sort the nodes of the dom in-place, based on a comparison function.
     """
@@ -95,10 +95,6 @@ def sort_nodes(dom, cmp_func):
         while prev_sib and cmp_func(prev_sib, node) == 1:
             node.parentNode.insertBefore(node, prev_sib)
             prev_sib = node.previousSibling
-
-
-def sort_del_before_ins(dom):
-    sort_nodes(dom, cmp_func=node_compare)
 
 
 def merge_adjacent(dom, tag_name):

--- a/htmltreediff/changes.py
+++ b/htmltreediff/changes.py
@@ -124,17 +124,3 @@ def distribute(node):
     tag_name = node.tagName
     for c in children:
         wrap_inner(c, tag_name)
-
-
-def _strip_changes_new(node):
-    for ins_node in node.getElementsByTagName('ins'):
-        unwrap(ins_node)
-    for del_node in node.getElementsByTagName('del'):
-        remove_node(del_node)
-
-
-def _strip_changes_old(node):
-    for ins_node in node.getElementsByTagName('ins'):
-        remove_node(ins_node)
-    for del_node in node.getElementsByTagName('del'):
-        unwrap(del_node)

--- a/htmltreediff/html.py
+++ b/htmltreediff/html.py
@@ -153,7 +153,7 @@ def add_class_to_empty_del_tags(dom):
             for child in node.childNodes:
                 if child.nodeType == node.TEXT_NODE:
                     # Confirm that the text is all whitespace
-                    if not re.match('^\s*$', child.nodeValue):
+                    if not re.match(r'^\s*$', child.nodeValue):
                         all_blank = False
                         break
                 else:

--- a/htmltreediff/html.py
+++ b/htmltreediff/html.py
@@ -11,6 +11,8 @@ from htmltreediff.util import (
 )
 from htmltreediff.changes import dom_diff, distribute
 
+import re
+
 
 def diff(old_html, new_html, cutoff=0.0, plaintext=False, pretty=False):
     """Show the differences between the old and new html document, as html.
@@ -39,6 +41,7 @@ def diff(old_html, new_html, cutoff=0.0, plaintext=False, pretty=False):
     if not plaintext:
         fix_lists(dom)
         fix_tables(dom)
+        add_class_to_empty_del_tags(dom)
 
     # Only return html for the document body contents.
     body_elements = dom.getElementsByTagName('body')
@@ -139,3 +142,25 @@ def fix_tables(dom):
         parent = node.parentNode
         if parent.tagName in ['table', 'tbody', 'thead', 'tfoot', 'tr']:
             remove_node(node)
+
+
+def add_class_to_empty_del_tags(dom):
+    for node in dom.getElementsByTagName('del'):
+        if not node.hasChildNodes():
+            node.setAttribute('class', 'empty')
+        else:
+            all_blank = True
+            for child in node.childNodes:
+                if child.nodeType == node.TEXT_NODE:
+                    # Confirm that the text is all whitespace
+                    if not re.match('^\s*$', child.nodeValue):
+                        all_blank = False
+                        break
+                else:
+                    # will not mark del tags with child elements
+                    # For future improvement: search for any nonwhitespace text
+                    # or block element that is expected to be visible
+                    all_blank = False
+                    break
+            if all_blank:
+                node.setAttribute('class', 'empty')

--- a/htmltreediff/test_html.py
+++ b/htmltreediff/test_html.py
@@ -626,3 +626,5 @@ def test_add_class_to_empty_del_tags():
             dom = parse_minidom(test_input, strict_xml=True)
             add_class_to_empty_del_tags(dom)
             assert_html_equal(minidom_tostring(dom), expected_result)
+        test.description = 'test_add_class_to_empty_del_tags - %s' % test_name
+        yield test

--- a/htmltreediff/test_html.py
+++ b/htmltreediff/test_html.py
@@ -5,7 +5,7 @@ from nose.tools import assert_equal
 from htmltreediff.html import diff
 from htmltreediff.tests import assert_html_equal
 from htmltreediff.changes import distribute
-from htmltreediff.html import fix_lists, fix_tables
+from htmltreediff.html import add_class_to_empty_del_tags, fix_lists, fix_tables
 from htmltreediff.util import (
     parse_minidom,
     minidom_tostring,
@@ -595,3 +595,34 @@ def test_fix_tables():
             assert_html_equal(minidom_tostring(changes_dom), fixed_changes)
         test.description = 'test_fix_tables - %s' % test_name
         yield test
+
+
+def test_add_class_to_empty_del_tags():
+    cases = [
+        (
+            'empty del tag',
+            '<del></del>',
+            '<del class="empty"/>',
+        ),
+        (
+            'del tag with space',
+            '<del> </del>',
+            '<del class="empty"> </del>',
+        ),
+        (
+            'del tag with child',
+            '<del> <p> </p> </del>',
+            '<del> <p> </p> </del>',
+        ),
+        (
+            'del tag with spaces and characters',
+            '<del> abc </del>',
+            '<del> abc </del>',
+        ),
+
+    ]
+    for test_name, test_input, expected_result in cases:
+        def test():
+            dom = parse_minidom(test_input, strict_xml=True)
+            add_class_to_empty_del_tags(dom)
+            assert_html_equal(minidom_tostring(dom), expected_result)

--- a/htmltreediff/test_util.py
+++ b/htmltreediff/test_util.py
@@ -2,7 +2,7 @@ from htmltreediff.diff_core import Differ
 from htmltreediff.edit_script_runner import EditScriptRunner
 from htmltreediff.changes import (
     split_text_nodes,
-    sort_del_before_ins,
+    sort_nodes,
 )
 from htmltreediff.util import (
     attribute_dict,
@@ -43,7 +43,7 @@ def reverse_changes(dom):
             node.tagName = 'ins'
         elif node.tagName == 'ins':
             node.tagName = 'del'
-    sort_del_before_ins(dom)
+    sort_nodes(dom)
 
 
 def get_edit_script(old_html, new_html):

--- a/htmltreediff/test_util.py
+++ b/htmltreediff/test_util.py
@@ -3,14 +3,14 @@ from htmltreediff.edit_script_runner import EditScriptRunner
 from htmltreediff.changes import (
     split_text_nodes,
     sort_del_before_ins,
-    _strip_changes_new,
-    _strip_changes_old,
 )
 from htmltreediff.util import (
+    attribute_dict,
     minidom_tostring,
     node_compare,
     parse_minidom,
-    remove_dom_attributes,
+    remove_node,
+    unwrap,
     walk_dom,
 )
 
@@ -18,16 +18,14 @@ from htmltreediff.util import (
 def reverse_edit_script(edit_script):
     if edit_script is None:
         return None
-
-    def opposite_action(action):
-        if action == 'delete':
-            return 'insert'
-        elif action == 'insert':
-            return 'delete'
+    opposite_command = {
+        'insert': 'delete',
+        'delete': 'insert',
+    }
     reverse_script = []
     for action, location, node_properties in reversed(edit_script):
         reverse_script.append(
-            (opposite_action(action), location, node_properties),
+            (opposite_command[action], location, node_properties),
         )
     return reverse_script
 
@@ -64,6 +62,20 @@ def html_patch(old_html, edit_script):
     return minidom_tostring(runner.run_edit_script())
 
 
+def _strip_changes_new(node):
+    for ins_node in node.getElementsByTagName('ins'):
+        unwrap(ins_node)
+    for del_node in node.getElementsByTagName('del'):
+        remove_node(del_node)
+
+
+def _strip_changes_old(node):
+    for ins_node in node.getElementsByTagName('ins'):
+        remove_node(ins_node)
+    for del_node in node.getElementsByTagName('del'):
+        unwrap(del_node)
+
+
 def strip_changes_old(html):
     dom = parse_minidom(html)
     _strip_changes_old(dom)
@@ -74,6 +86,12 @@ def strip_changes_new(html):
     dom = parse_minidom(html)
     _strip_changes_new(dom)
     return minidom_tostring(dom)
+
+
+def remove_dom_attributes(dom):
+    for node in walk_dom(dom):
+        for key in attribute_dict(node).keys():
+            node.attributes.removeNamedItem(key)
 
 
 def remove_attributes(html):

--- a/htmltreediff/tests.py
+++ b/htmltreediff/tests.py
@@ -1030,18 +1030,18 @@ insane_test_cases = [
         '<p>line one line two</p>',
         '<p>line one line two</p>',
     ),
-#    (
-#        'ignore adding attributes',
-#        '<h1>one</h1>',
-#        '<h1 id="ignore" class="ignore">one</h1>',
-#        '<h1>one</h1>',
-#    ),
-#    (
-#        'ignore deleting attributes',
-#        '<h1 id="ignore" class="ignore">one</h1>',
-#        '<h1>one</h1>',
-#        '<h1 id="ignore" class="ignore">one</h1>',
-#    ),
+    # (
+    #     'ignore adding attributes',
+    #     '<h1>one</h1>',
+    #     '<h1 id="ignore" class="ignore">one</h1>',
+    #     '<h1>one</h1>',
+    # ),
+    # (
+    #     'ignore deleting attributes',
+    #     '<h1 id="ignore" class="ignore">one</h1>',
+    #     '<h1>one</h1>',
+    #     '<h1 id="ignore" class="ignore">one</h1>',
+    # ),
     (
         'whitespace changes in a table with colspan',
         '''

--- a/htmltreediff/text.py
+++ b/htmltreediff/text.py
@@ -14,13 +14,13 @@ def full_split(text, regex):
     ['word']
     """
     while text:
-        m = regex.search(text)
-        if not m:
+        matcher = regex.search(text)
+        if not matcher:
             yield text
             break
-        left = text[:m.start()]
-        middle = text[m.start():m.end()]
-        right = text[m.end():]
+        left = text[:matcher.start()]
+        middle = text[matcher.start():matcher.end()]
+        right = text[matcher.end():]
         if left:
             yield left
         if middle:

--- a/htmltreediff/util.py
+++ b/htmltreediff/util.py
@@ -95,7 +95,7 @@ def remove_comments(xml):
     return regex.sub('', xml)
 
 
-def remove_non_printing_characters(xml, replace_char=u' '):
+def remove_non_printing_characters(xml, replace_char=' '):
     r'''
     Replace non-printing characters from the XML with spaces, otherwise it
     interferes with the XML parsing
@@ -241,10 +241,10 @@ def attribute_dict(node):
 
 def normalize_entities(html):
     # turn &nbsp; and aliases into normal spaces
-    html = html.replace(u'&nbsp;', u' ')
-    html = html.replace(u'&#160;', u' ')
-    html = html.replace(u'&#xA0;', u' ')
-    html = html.replace(u'\xa0', u' ')
+    html = html.replace('&nbsp;', ' ')
+    html = html.replace('&#160;', ' ')
+    html = html.replace('&#xA0;', ' ')
+    html = html.replace('\xa0', ' ')
     return html
 
 

--- a/htmltreediff/util.py
+++ b/htmltreediff/util.py
@@ -234,7 +234,7 @@ def attribute_dict(node):
     if not node.attributes:
         return {}
     d = dict(node.attributes)
-    for key, node in list(d.items()):
+    for key, node in d.items():
         d[key] = node.value
     return d
 

--- a/htmltreediff/util.py
+++ b/htmltreediff/util.py
@@ -253,12 +253,6 @@ def remove_xml_declaration(xml):
     return re.sub(r'<\?xml.*\?>', '', xml).strip()
 
 
-def remove_dom_attributes(dom):
-    for node in walk_dom(dom):
-        for key in attribute_dict(node).keys():
-            node.attributes.removeNamedItem(key)
-
-
 _non_text_node_tags = [
     'html', 'head', 'table', 'thead', 'tbody', 'tfoot', 'tr', 'colgroup',
     'col', 'ul', 'ol', 'dl', 'select', 'img', 'br', 'hr',

--- a/requirements/default.txt
+++ b/requirements/default.txt
@@ -1,3 +1,3 @@
 html5lib==0.90
 lxml==4.2.5
-six
+six==1.15.0

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,3 +1,3 @@
-coverage==3.7
-nose==1.3
+coverage
+nose
 flake8

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -1,3 +1,3 @@
 coverage==3.7
 nose==1.3
-flake8<=3
+flake8

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,8 @@ except ImportError:
 long_description = codecs.open("README.rst", "r", "utf-8").read()
 
 
-def strip_comments(l):
-    return l.split('#', 1)[0].strip()
+def strip_comments(line):
+    return line.split('#', 1)[0].strip()
 
 
 def get_requirements(path):
@@ -27,11 +27,11 @@ def get_requirements(path):
 
 setup(
     name="html-tree-diff",
-    version="0.1.4",
+    version="0.3.0",
     description="Structure-aware diff for html and xml documents",
     author="Christian Oudard",
     author_email="christian.oudard@gmail.com",
-    url="http://github.com/christian-oudard/htmltreediff/",
+    url="http://github.com/PolicyStat/htmltreediff/",
     platforms=["any"],
     license="BSD",
     packages=find_packages(),


### PR DESCRIPTION
Add class "empty" to del tags which are empty or only contain only space characters.
In the future, we might recursively search for non-space characters within tags or consider certain tags to be visually displayed. This is out of the current scope.
CSS to style the marked tags should be handled on the client side.