### PR TITLE
Tables are being removed when the diff adds `ins` or `del` tags wrapping `tbody`/`thead`/`tfoot` tags

### DIFF
--- a/htmltreediff/diff_core.py
+++ b/htmltreediff/diff_core.py
@@ -373,7 +373,7 @@ def fuzzy_match_blocks(old_children, new_children):
     B==C but A!=C, elements get merged into incorrect groups and the longest
     common subsequence is computed on wrong groupings.
 
-    Explaination: https://www.geeksforgeeks.org/dsa/longest-common-subsequence-dp-4/#expected-approach-1-using-bottomup-dp-tabulation-om-n-time-and-om-n-space
+    Explaination: https://www.geeksforgeeks.org/dsa/longest-common-subsequence-dp-4/#expected-approach-1-using-bottomup-dp-tabulation-om-n-time-and-om-n-space  # noqa E501
     """
     n = len(old_children)
     m = len(new_children)

--- a/htmltreediff/diff_core.py
+++ b/htmltreediff/diff_core.py
@@ -307,6 +307,62 @@ def _has_fuzzy_hash_collisions(children):
     return False
 
 
+def build_pairwise_match_matrix(old_hashes, new_hashes):
+    n = len(old_hashes)
+    m = len(new_hashes)
+    match_matrix = [[False] * m for _ in range(n)]
+    for i in range(n):
+        for j in range(m):
+            match_matrix[i][j] = (old_hashes[i] == new_hashes[j])
+    return match_matrix
+
+
+def compute_longest_common_subsequence_lengths_table(match_matrix):
+    n = len(match_matrix)
+    m = len(match_matrix[0]) if n > 0 else 0
+    lcs_lengths = [[0] * (m + 1) for _ in range(n + 1)]
+    for i in reversed(range(n)):
+        for j in reversed(range(m)):
+            if match_matrix[i][j]:
+                lcs_lengths[i][j] = 1 + lcs_lengths[i + 1][j + 1]
+            else:
+                lcs_lengths[i][j] = max(lcs_lengths[i + 1][j], lcs_lengths[i][j + 1])
+    return lcs_lengths
+
+
+def traceback_longest_common_subsequence_matched_pairs(match_matrix, lcs_lengths):
+    n = len(match_matrix)
+    m = len(match_matrix[0]) if n > 0 else 0
+    matched_pairs = []
+    i, j = 0, 0
+    while i < n and j < m:
+        if match_matrix[i][j] and lcs_lengths[i][j] == 1 + lcs_lengths[i + 1][j + 1]:
+            matched_pairs.append((i, j))
+            i += 1
+            j += 1
+        elif lcs_lengths[i + 1][j] >= lcs_lengths[i][j + 1]:
+            i += 1
+        else:
+            j += 1
+    return matched_pairs
+
+
+def group_consecutive_pairs_into_blocks(matched_pairs, n, m):
+    blocks = []
+    k = 0
+    while k < len(matched_pairs):
+        a, b = matched_pairs[k]
+        size = 1
+        while (
+            k + size < len(matched_pairs) and matched_pairs[k + size] == (a + size, b + size)
+        ):
+            size += 1
+        blocks.append((a, b, size))
+        k += size
+    blocks.append((n, m, 0))  # sentinel
+    return blocks
+
+
 def fuzzy_match_blocks(old_children, new_children):
     """Find matching blocks using direct pairwise fuzzy comparison.
 
@@ -316,9 +372,6 @@ def fuzzy_match_blocks(old_children, new_children):
     SequenceMatcher groups elements into a dict by equality, so when A==B and
     B==C but A!=C, elements get merged into incorrect groups and the longest
     common subsequence is computed on wrong groupings.
-
-    This function builds an explicit pairwise match matrix and finds the LCS
-    using dynamic programming, which correctly handles non-transitive equality.
     """
     n = len(old_children)
     m = len(new_children)
@@ -326,52 +379,16 @@ def fuzzy_match_blocks(old_children, new_children):
     if n == 0 or m == 0:
         return [(n, m, 0)]
 
-    # Build pairwise match matrix.
     old_hashes = [fuzzy_match_node_hash(c) for c in old_children]
     new_hashes = [fuzzy_match_node_hash(c) for c in new_children]
-    match = [[False] * m for _ in range(n)]
-    for i in range(n):
-        for j in range(m):
-            match[i][j] = (old_hashes[i] == new_hashes[j])
 
-    # Find longest common subsequence via dynamic programming.
-    dp = [[0] * (m + 1) for _ in range(n + 1)]
-    for i in range(n - 1, -1, -1):
-        for j in range(m - 1, -1, -1):
-            if match[i][j]:
-                dp[i][j] = 1 + dp[i + 1][j + 1]
-            else:
-                dp[i][j] = max(dp[i + 1][j], dp[i][j + 1])
-
-    # Traceback to find matched pairs.
-    matches = []
-    i, j = 0, 0
-    while i < n and j < m:
-        if match[i][j] and dp[i][j] == 1 + dp[i + 1][j + 1]:
-            matches.append((i, j))
-            i += 1
-            j += 1
-        elif dp[i + 1][j] >= dp[i][j + 1]:
-            i += 1
-        else:
-            j += 1
-
-    # Convert matched pairs to matching blocks (consecutive diagonal
-    # matches are grouped into a single block).
-    blocks = []
-    k = 0
-    while k < len(matches):
-        a, b = matches[k]
-        size = 1
-        while (k + size < len(matches)
-               and matches[k + size] == (a + size, b + size)):
-            size += 1
-        blocks.append((a, b, size))
-        k += size
-
-    # Add sentinel.
-    blocks.append((n, m, 0))
-    return blocks
+    match_matrix = build_pairwise_match_matrix(old_hashes, new_hashes)
+    lcs_lengths = compute_longest_common_subsequence_lengths_table(match_matrix)
+    matched_pairs = traceback_longest_common_subsequence_matched_pairs(
+        match_matrix,
+        lcs_lengths,
+    )
+    return group_consecutive_pairs_into_blocks(matched_pairs, n, m)
 
 
 def get_nonmatching_blocks(matching_blocks):

--- a/htmltreediff/diff_core.py
+++ b/htmltreediff/diff_core.py
@@ -8,7 +8,7 @@ from htmltreediff.util import (
     copy_dom,
     HashableTree,
     FuzzyHashableTree,
-    is_element,
+    dom_node_in_table_context,
     is_text,
     get_child,
     get_location,
@@ -17,13 +17,6 @@ from htmltreediff.util import (
     attribute_dict,
     walk_dom,
 )
-
-# Tags that constitute a table structure. The fuzzy LCS diff path is
-# restricted to children of these elements to avoid O(n*m) cost on large
-# non-table documents.
-TABLE_ELEMENT_TAGS = {
-    'table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th', 'caption', 'colgroup', 'col',
-}
 
 
 def match_node_hash(node):
@@ -82,13 +75,10 @@ class Differ():
         if not old_children and not new_children:
             return
 
-        tag = old_parent.tagName.lower() if is_element(old_parent) else None
-        in_table_context = tag in TABLE_ELEMENT_TAGS
-
         matching_blocks, recursion_indices = self.match_children(
             old_children,
             new_children,
-            in_table_context=in_table_context,
+            in_table_context=dom_node_in_table_context(old_parent),
         )
 
         # Apply changes for this level.

--- a/htmltreediff/diff_core.py
+++ b/htmltreediff/diff_core.py
@@ -8,6 +8,7 @@ from htmltreediff.util import (
     copy_dom,
     HashableTree,
     FuzzyHashableTree,
+    is_element,
     is_text,
     get_child,
     get_location,
@@ -16,6 +17,13 @@ from htmltreediff.util import (
     attribute_dict,
     walk_dom,
 )
+
+# Tags that constitute a table structure. The fuzzy LCS diff path is
+# restricted to children of these elements to avoid O(n*m) cost on large
+# non-table documents.
+TABLE_ELEMENT_TAGS = {
+    'table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th', 'caption', 'colgroup', 'col',
+}
 
 
 def match_node_hash(node):
@@ -66,18 +74,21 @@ class Differ():
         # the text-similar matches and the tag-only matches, we still have more
         # work to do, so we recurse on these. The non-matching parts that
         # remain are used to output edit script entries.
-        old_children = list(
-            get_location(self.old_dom, old_location).childNodes,
-        )
+        old_parent = get_location(self.old_dom, old_location)
+        old_children = list(old_parent.childNodes)
         new_children = list(
             get_location(self.new_dom, new_location).childNodes,
         )
         if not old_children and not new_children:
             return
 
+        tag = old_parent.tagName.lower() if is_element(old_parent) else None
+        in_table_context = tag in TABLE_ELEMENT_TAGS
+
         matching_blocks, recursion_indices = self.match_children(
             old_children,
             new_children,
+            in_table_context=in_table_context,
         )
 
         # Apply changes for this level.
@@ -106,7 +117,7 @@ class Differ():
                 new_location + [new_index],
             )
 
-    def match_children(self, old_children, new_children):
+    def match_children(self, old_children, new_children, in_table_context=False):
         # Find whole-tree matches and fuzzy matches.
         sm = match_blocks(match_node_hash, old_children, new_children)
         # If the match is very poor, pretend there were no exact matching
@@ -124,7 +135,7 @@ class Differ():
             alo, ahi, blo, bhi = nonmatch
             gap_old = old_children[alo:ahi]
             gap_new = new_children[blo:bhi]
-            if _has_fuzzy_hash_collisions(gap_new):
+            if in_table_context and _has_fuzzy_hash_collisions(gap_new):
                 blocks = fuzzy_match_blocks(gap_old, gap_new)
             else:
                 sm_fuzzy = match_blocks(
@@ -373,7 +384,7 @@ def fuzzy_match_blocks(old_children, new_children):
     B==C but A!=C, elements get merged into incorrect groups and the longest
     common subsequence is computed on wrong groupings.
 
-    Explaination: https://www.geeksforgeeks.org/dsa/longest-common-subsequence-dp-4/#expected-approach-1-using-bottomup-dp-tabulation-om-n-time-and-om-n-space  # noqa E501
+    Explanation: https://www.geeksforgeeks.org/dsa/longest-common-subsequence-dp-4/#expected-approach-1-using-bottomup-dp-tabulation-om-n-time-and-om-n-space  # noqa E501
     """
     n = len(old_children)
     m = len(new_children)

--- a/htmltreediff/diff_core.py
+++ b/htmltreediff/diff_core.py
@@ -372,6 +372,8 @@ def fuzzy_match_blocks(old_children, new_children):
     SequenceMatcher groups elements into a dict by equality, so when A==B and
     B==C but A!=C, elements get merged into incorrect groups and the longest
     common subsequence is computed on wrong groupings.
+
+    Explaination: https://www.geeksforgeeks.org/dsa/longest-common-subsequence-dp-4/#expected-approach-1-using-bottomup-dp-tabulation-om-n-time-and-om-n-space
     """
     n = len(old_children)
     m = len(new_children)

--- a/htmltreediff/diff_core.py
+++ b/htmltreediff/diff_core.py
@@ -122,12 +122,17 @@ class Differ():
         fuzzy_matching_blocks = [(0, 0, 0)]
         for nonmatch in gaps:
             alo, ahi, blo, bhi = nonmatch
-            sm_fuzzy = match_blocks(
-                fuzzy_match_node_hash,
-                old_children[alo:ahi],
-                new_children[blo:bhi],
-            )
-            blocks = sm_fuzzy.get_matching_blocks()
+            gap_old = old_children[alo:ahi]
+            gap_new = new_children[blo:bhi]
+            if _has_fuzzy_hash_collisions(gap_new):
+                blocks = fuzzy_match_blocks(gap_old, gap_new)
+            else:
+                sm_fuzzy = match_blocks(
+                    fuzzy_match_node_hash,
+                    gap_old,
+                    gap_new,
+                )
+                blocks = sm_fuzzy.get_matching_blocks()
             # Move blocks over to the position of the gap.
             blocks = [
                 (alo + a, blo + b, size)
@@ -281,6 +286,92 @@ def match_blocks(hash_func, old_children, new_children):
         b=[hash_func(c) for c in new_children],
     )
     return sm
+
+
+def _has_fuzzy_hash_collisions(children):
+    """Check if element children have hash collisions in fuzzy matching.
+
+    When multiple element nodes hash to the same FuzzyHashableTree value,
+    SequenceMatcher may group them incorrectly due to non-transitive equality,
+    causing misaligned matches. Text nodes use string equality (which is
+    transitive) and are not affected.
+    """
+    seen_hashes = set()
+    for c in children:
+        if is_text(c):
+            continue
+        h = hash(fuzzy_match_node_hash(c))
+        if h in seen_hashes:
+            return True
+        seen_hashes.add(h)
+    return False
+
+
+def fuzzy_match_blocks(old_children, new_children):
+    """Find matching blocks using direct pairwise fuzzy comparison.
+
+    Unlike match_blocks (which uses SequenceMatcher), this compares each
+    old-new pair individually using FuzzyHashableTree. This avoids
+    misalignment caused by FuzzyHashableTree's non-transitive equality:
+    SequenceMatcher groups elements into a dict by equality, so when A==B and
+    B==C but A!=C, elements get merged into incorrect groups and the longest
+    common subsequence is computed on wrong groupings.
+
+    This function builds an explicit pairwise match matrix and finds the LCS
+    using dynamic programming, which correctly handles non-transitive equality.
+    """
+    n = len(old_children)
+    m = len(new_children)
+
+    if n == 0 or m == 0:
+        return [(n, m, 0)]
+
+    # Build pairwise match matrix.
+    old_hashes = [fuzzy_match_node_hash(c) for c in old_children]
+    new_hashes = [fuzzy_match_node_hash(c) for c in new_children]
+    match = [[False] * m for _ in range(n)]
+    for i in range(n):
+        for j in range(m):
+            match[i][j] = (old_hashes[i] == new_hashes[j])
+
+    # Find longest common subsequence via dynamic programming.
+    dp = [[0] * (m + 1) for _ in range(n + 1)]
+    for i in range(n - 1, -1, -1):
+        for j in range(m - 1, -1, -1):
+            if match[i][j]:
+                dp[i][j] = 1 + dp[i + 1][j + 1]
+            else:
+                dp[i][j] = max(dp[i + 1][j], dp[i][j + 1])
+
+    # Traceback to find matched pairs.
+    matches = []
+    i, j = 0, 0
+    while i < n and j < m:
+        if match[i][j] and dp[i][j] == 1 + dp[i + 1][j + 1]:
+            matches.append((i, j))
+            i += 1
+            j += 1
+        elif dp[i + 1][j] >= dp[i][j + 1]:
+            i += 1
+        else:
+            j += 1
+
+    # Convert matched pairs to matching blocks (consecutive diagonal
+    # matches are grouped into a single block).
+    blocks = []
+    k = 0
+    while k < len(matches):
+        a, b = matches[k]
+        size = 1
+        while (k + size < len(matches)
+               and matches[k + size] == (a + size, b + size)):
+            size += 1
+        blocks.append((a, b, size))
+        k += size
+
+    # Add sentinel.
+    blocks.append((n, m, 0))
+    return blocks
 
 
 def get_nonmatching_blocks(matching_blocks):

--- a/htmltreediff/html.py
+++ b/htmltreediff/html.py
@@ -117,25 +117,26 @@ def fix_lists(dom):
                 wrap_inner(c, 'del')
 
 
+def distribute_ins_and_del_tags(dom, tag_names):
+    tags = set()
+    for tag_name in tag_names:
+        for node in list(dom.getElementsByTagName(tag_name)):
+            parent = node.parentNode
+            if parent.tagName in ('ins', 'del'):
+                tags.add(parent)
+    for tag in tags:
+        distribute(tag)
+
+
 def fix_tables(dom):
+    _internalize_changes_markup(dom, set(['tbody', 'thead', 'tfoot']))
+    _internalize_changes_markup(dom, set(['tr']))
     _internalize_changes_markup(dom, set(['td', 'th']))
 
-    # Show table row insertions
-    tags = set()
-    for node in list(dom.getElementsByTagName('tr')):
-        parent = node.parentNode
-        if parent.tagName in ('ins', 'del'):
-            tags.add(parent)
-    for tag in tags:
-        distribute(tag)
-    # Show table cell insertions
-    tags = set()
-    for node in list(dom.getElementsByTagName('td') + dom.getElementsByTagName('th')):
-        parent = node.parentNode
-        if parent.tagName in ('ins', 'del'):
-            tags.add(parent)
-    for tag in tags:
-        distribute(tag)
+    distribute_ins_and_del_tags(dom, ['tbody', 'thead', 'tfoot'])
+    distribute_ins_and_del_tags(dom, ['tr'])
+    distribute_ins_and_del_tags(dom, ['td', 'th'])
+
     # All other ins and del tags inside a table but not in a cell are invalid,
     # so remove them.
     for node in list(dom.getElementsByTagName('ins') + dom.getElementsByTagName('del')):

--- a/htmltreediff/test_diff_core.py
+++ b/htmltreediff/test_diff_core.py
@@ -1,3 +1,6 @@
+# coding: utf-8
+from unittest.mock import patch
+
 from nose.tools import assert_equal
 
 from htmltreediff.diff_core import (
@@ -7,11 +10,12 @@ from htmltreediff.diff_core import (
     fuzzy_match_blocks,
     group_consecutive_pairs_into_blocks,
     traceback_longest_common_subsequence_matched_pairs,
+    Differ,
 )
 from htmltreediff.util import parse_minidom
 
 
-def children_of(html):
+def get_dom_nodes(html):
     dom = parse_minidom('<section>{}</section>'.format(html))
     return list(dom.getElementsByTagName('section')[0].childNodes)
 
@@ -25,17 +29,17 @@ def test_has_fuzzy_hash_collisions_no_children():
 
 def test_has_fuzzy_hash_collisions_all_distinct_tags():
     # <p> and <h1> have different tags so different hashes — no collision
-    assert_equal(_has_fuzzy_hash_collisions(children_of('<p>a</p><h1>b</h1>')), False)
+    assert_equal(_has_fuzzy_hash_collisions(get_dom_nodes('<p>a</p><h1>b</h1>')), False)
 
 
 def test_has_fuzzy_hash_collisions_same_tag_twice_is_collision():
     # Two <p> elements: same tag → same FuzzyHashableTree hash → collision
-    assert_equal(_has_fuzzy_hash_collisions(children_of('<p>a</p><p>b</p>')), True)
+    assert_equal(_has_fuzzy_hash_collisions(get_dom_nodes('<p>a</p><p>b</p>')), True)
 
 
 def test_has_fuzzy_hash_collisions_text_nodes_ignored():
     # Text nodes are skipped; only two distinct element tags → no collision
-    assert_equal(_has_fuzzy_hash_collisions(children_of('hello <p>a</p><h1>b</h1>')), False)
+    assert_equal(_has_fuzzy_hash_collisions(get_dom_nodes('hello <p>a</p><h1>b</h1>')), False)
 
 
 # --- build_pairwise_match_matrix ---
@@ -134,27 +138,57 @@ def test_group_non_consecutive_pairs_become_separate_blocks():
 
 
 def test_fuzzy_match_blocks_empty_old():
-    assert_equal(fuzzy_match_blocks([], children_of('<p>hello</p>')), [(0, 1, 0)])
+    assert_equal(fuzzy_match_blocks([], get_dom_nodes('<p>hello</p>')), [(0, 1, 0)])
 
 
 def test_fuzzy_match_blocks_empty_new():
-    assert_equal(fuzzy_match_blocks(children_of('<p>hello</p>'), []), [(1, 0, 0)])
+    assert_equal(fuzzy_match_blocks(get_dom_nodes('<p>hello</p>'), []), [(1, 0, 0)])
 
 
 def test_fuzzy_match_blocks_similar_text_same_tag_matches():
-    old = children_of('<p>Hello world</p>')
-    new = children_of('<p>Hello earth</p>')
+    old = get_dom_nodes('<p>Hello world</p>')
+    new = get_dom_nodes('<p>Hello earth</p>')
     assert_equal(fuzzy_match_blocks(old, new), [(0, 0, 1), (1, 1, 0)])
 
 
 def test_fuzzy_match_blocks_different_tag_does_not_match():
-    old = children_of('<p>Hello world</p>')
-    new = children_of('<h1>Hello world</h1>')
+    old = get_dom_nodes('<p>Hello world</p>')
+    new = get_dom_nodes('<h1>Hello world</h1>')
     assert_equal(fuzzy_match_blocks(old, new), [(1, 1, 0)])
 
 
 def test_fuzzy_match_blocks_unmatched_node_excluded_from_blocks():
     # old[0] and old[1] fuzzy-match new[0] and new[1]; old[2] has no match
-    old = children_of('<p>Hello world</p><p>Foo bar</p><h2>Other</h2>')
-    new = children_of('<p>Hello earth</p><p>Foo bar</p>')
+    old = get_dom_nodes('<p>Hello world</p><p>Foo bar</p><h2>Other</h2>')
+    new = get_dom_nodes('<p>Hello earth</p><p>Foo bar</p>')
     assert_equal(fuzzy_match_blocks(old, new), [(0, 0, 2), (3, 2, 0)])
+
+
+# --- table-context restriction for fuzzy_match_blocks ---
+
+
+def _make_differ():
+    empty = parse_minidom('<html></html>')
+    return Differ(empty, empty)
+
+
+def test_fuzzy_match_not_called_outside_table_context():
+    old = get_dom_nodes('<p>Alpha paragraph.</p><p>Beta paragraph.</p>')
+    new = get_dom_nodes('<p>Alpha changed.</p><p>Beta changed.</p>')
+    with patch(
+        'htmltreediff.diff_core.fuzzy_match_blocks',
+        wraps=fuzzy_match_blocks,
+    ) as spy:
+        _make_differ().match_children(old, new, in_table_context=False)
+    spy.assert_not_called()
+
+
+def test_fuzzy_match_called_inside_table_context():
+    old = get_dom_nodes('<tr><td>Row one old</td></tr><tr><td>Row two old</td></tr>')
+    new = get_dom_nodes('<tr><td>Row one new</td></tr><tr><td>Row two new</td></tr>')
+    with patch(
+        'htmltreediff.diff_core.fuzzy_match_blocks',
+        wraps=fuzzy_match_blocks,
+    ) as spy:
+        _make_differ().match_children(old, new, in_table_context=True)
+    spy.assert_called()

--- a/htmltreediff/test_diff_core.py
+++ b/htmltreediff/test_diff_core.py
@@ -1,0 +1,160 @@
+from nose.tools import assert_equal
+
+from htmltreediff.diff_core import (
+    _has_fuzzy_hash_collisions,
+    build_pairwise_match_matrix,
+    compute_longest_common_subsequence_lengths_table,
+    fuzzy_match_blocks,
+    group_consecutive_pairs_into_blocks,
+    traceback_longest_common_subsequence_matched_pairs,
+)
+from htmltreediff.util import parse_minidom
+
+
+def children_of(html):
+    dom = parse_minidom('<section>{}</section>'.format(html))
+    return list(dom.getElementsByTagName('section')[0].childNodes)
+
+
+# --- _has_fuzzy_hash_collisions ---
+
+
+def test_has_fuzzy_hash_collisions_no_children():
+    assert_equal(_has_fuzzy_hash_collisions([]), False)
+
+
+def test_has_fuzzy_hash_collisions_all_distinct_tags():
+    # <p> and <h1> have different tags so different hashes — no collision
+    assert_equal(_has_fuzzy_hash_collisions(children_of('<p>a</p><h1>b</h1>')), False)
+
+
+def test_has_fuzzy_hash_collisions_same_tag_twice_is_collision():
+    # Two <p> elements: same tag → same FuzzyHashableTree hash → collision
+    assert_equal(_has_fuzzy_hash_collisions(children_of('<p>a</p><p>b</p>')), True)
+
+
+def test_has_fuzzy_hash_collisions_text_nodes_ignored():
+    # Text nodes are skipped; only two distinct element tags → no collision
+    assert_equal(_has_fuzzy_hash_collisions(children_of('hello <p>a</p><h1>b</h1>')), False)
+
+
+# --- build_pairwise_match_matrix ---
+
+
+def test_build_pairwise_match_matrix_no_matches():
+    assert_equal(
+        build_pairwise_match_matrix(['a', 'b'], ['c', 'd']),
+        [[False, False], [False, False]],
+    )
+
+
+def test_build_pairwise_match_matrix_some_matches():
+    assert_equal(
+        build_pairwise_match_matrix(['a', 'b'], ['b', 'c']),
+        [[False, False], [True, False]],
+    )
+
+
+def test_build_pairwise_match_matrix_empty():
+    assert_equal(build_pairwise_match_matrix([], []), [])
+
+
+# --- compute_longest_common_subsequence_lengths_table ---
+
+
+def test_lcs_lengths_no_matches():
+    match_matrix = [[False, False], [False, False]]
+    lcs_lengths = compute_longest_common_subsequence_lengths_table(match_matrix)
+    assert_equal(lcs_lengths[0][0], 0)
+
+
+def test_lcs_lengths_diagonal_matches_accumulate():
+    match_matrix = [[True, False], [False, True]]
+    lcs_lengths = compute_longest_common_subsequence_lengths_table(match_matrix)
+    assert_equal(lcs_lengths[0][0], 2)
+
+
+# --- traceback_longest_common_subsequence_matched_pairs ---
+
+
+def test_traceback_no_matches():
+    match_matrix = [[False, False], [False, False]]
+    lcs_lengths = compute_longest_common_subsequence_lengths_table(match_matrix)
+    assert_equal(
+        traceback_longest_common_subsequence_matched_pairs(match_matrix, lcs_lengths),
+        [],
+    )
+
+
+def test_traceback_two_diagonal_matches():
+    match_matrix = [[True, False], [False, True]]
+    lcs_lengths = compute_longest_common_subsequence_lengths_table(match_matrix)
+    assert_equal(
+        traceback_longest_common_subsequence_matched_pairs(match_matrix, lcs_lengths),
+        [(0, 0), (1, 1)],
+    )
+
+
+def test_traceback_skips_unmatched_old_node_to_reach_best_lcs():
+    # old = ['b', 'a'], new = ['a']
+    # old[0] does not match; old[1] does: result should be [(1, 0)], not []
+    match_matrix = [[False], [True]]
+    lcs_lengths = compute_longest_common_subsequence_lengths_table(match_matrix)
+    assert_equal(
+        traceback_longest_common_subsequence_matched_pairs(match_matrix, lcs_lengths),
+        [(1, 0)],
+    )
+
+
+# --- group_consecutive_pairs_into_blocks ---
+
+
+def test_group_no_pairs_produces_only_sentinel():
+    assert_equal(
+        group_consecutive_pairs_into_blocks([], 2, 3),
+        [(2, 3, 0)],
+    )
+
+
+def test_group_consecutive_pairs_merged_into_one_block():
+    assert_equal(
+        group_consecutive_pairs_into_blocks([(0, 0), (1, 1)], 2, 2),
+        [(0, 0, 2), (2, 2, 0)],
+    )
+
+
+def test_group_non_consecutive_pairs_become_separate_blocks():
+    assert_equal(
+        group_consecutive_pairs_into_blocks([(0, 0), (2, 2)], 3, 3),
+        [(0, 0, 1), (2, 2, 1), (3, 3, 0)],
+    )
+
+
+# --- fuzzy_match_blocks ---
+
+
+def test_fuzzy_match_blocks_empty_old():
+    assert_equal(fuzzy_match_blocks([], children_of('<p>hello</p>')), [(0, 1, 0)])
+
+
+def test_fuzzy_match_blocks_empty_new():
+    assert_equal(fuzzy_match_blocks(children_of('<p>hello</p>'), []), [(1, 0, 0)])
+
+
+def test_fuzzy_match_blocks_similar_text_same_tag_matches():
+    old = children_of('<p>Hello world</p>')
+    new = children_of('<p>Hello earth</p>')
+    assert_equal(fuzzy_match_blocks(old, new), [(0, 0, 1), (1, 1, 0)])
+
+
+def test_fuzzy_match_blocks_different_tag_does_not_match():
+    old = children_of('<p>Hello world</p>')
+    new = children_of('<h1>Hello world</h1>')
+    assert_equal(fuzzy_match_blocks(old, new), [(1, 1, 0)])
+
+
+def test_fuzzy_match_blocks_unmatched_node_excluded_from_blocks():
+    # old[0] and old[1] fuzzy-match new[0] and new[1]; old[2] has no match
+    old = children_of('<p>Hello world</p><p>Foo bar</p><h2>Other</h2>')
+    new = children_of('<p>Hello earth</p><p>Foo bar</p>')
+    assert_equal(fuzzy_match_blocks(old, new), [(0, 0, 2), (3, 2, 0)])

--- a/htmltreediff/test_html.py
+++ b/htmltreediff/test_html.py
@@ -553,6 +553,106 @@ def test_fix_tables():
             '''
         ),
         (
+            'tbody inside ins is distributed',
+            '''
+            <table>
+              <ins><tbody><tr><td>A</td></tr></tbody></ins>
+            </table>
+            ''',
+            '''
+            <table>
+              <tbody><tr><td><ins>A</ins></td></tr></tbody>
+            </table>
+            '''
+        ),
+        (
+            'tbody inside del is distributed',
+            '''
+            <table>
+              <del><tbody><tr><td>A</td></tr></tbody></del>
+            </table>
+            ''',
+            '''
+            <table>
+              <tbody><tr><td><del>A</del></td></tr></tbody>
+            </table>
+            '''
+        ),
+        (
+            'thead inside ins is distributed',
+            '''
+            <table>
+              <ins><thead><tr><th>Header</th></tr></thead></ins>
+              <tbody><tr><td>Data</td></tr></tbody>
+            </table>
+            ''',
+            '''
+            <table>
+              <thead><tr><th><ins>Header</ins></th></tr></thead>
+              <tbody><tr><td>Data</td></tr></tbody>
+            </table>
+            '''
+        ),
+        (
+            'thead inside del is distributed',
+            '''
+            <table>
+              <del><thead><tr><th>Header</th></tr></thead></del>
+              <tbody><tr><td>Data</td></tr></tbody>
+            </table>
+            ''',
+            '''
+            <table>
+              <thead><tr><th><del>Header</del></th></tr></thead>
+              <tbody><tr><td>Data</td></tr></tbody>
+            </table>
+            '''
+        ),
+        (
+            'tfoot inside ins is distributed',
+            '''
+            <table>
+              <tbody><tr><td>Data</td></tr></tbody>
+              <ins><tfoot><tr><td>Footer</td></tr></tfoot></ins>
+            </table>
+            ''',
+            '''
+            <table>
+              <tbody><tr><td>Data</td></tr></tbody>
+              <tfoot><tr><td><ins>Footer</ins></td></tr></tfoot>
+            </table>
+            '''
+        ),
+        (
+            'tfoot inside del is distributed',
+            '''
+            <table>
+              <tbody><tr><td>Data</td></tr></tbody>
+              <del><tfoot><tr><td>Footer</td></tr></tfoot></del>
+            </table>
+            ''',
+            '''
+            <table>
+              <tbody><tr><td>Data</td></tr></tbody>
+              <tfoot><tr><td><del>Footer</del></td></tr></tfoot>
+            </table>
+            '''
+        ),
+        (
+            'tbody del and ins pair is distributed',
+            '''
+            <table>
+              <del><tbody><tr><td>old data</td></tr></tbody></del>
+              <ins><tbody><tr><td>new data</td></tr></tbody></ins>
+            </table>
+            ''',
+            '''
+            <table>
+              <tbody><tr><td><del>old data</del><ins>new data</ins></td></tr></tbody>
+            </table>
+            '''
+        ),
+        (
             'remove ins and del tags at the wrong level of the table',
             '''
             <table>

--- a/htmltreediff/test_html.py
+++ b/htmltreediff/test_html.py
@@ -828,16 +828,16 @@ def test_similar_rows_not_misaligned_without_colgroup():
     """
     old_html = (
         '<table><tbody>'
-        '<tr><td>Alpha</td><td>shared setup text</td><td>Rate: check</td><td>Long notes requiring careful monitoring and administration throughout procedure.</td></tr>'
+        '<tr><td>Alpha</td><td>shared setup text</td><td>Rate: check</td><td>Long notes requiring careful monitoring and administration throughout procedure.</td></tr>'  # noqa E501
         '<tr><td>Beta</td><td>shared setup text</td><td>Rate: check</td><td>Rinse.</td></tr>'
         '<tr><td>Gamma</td><td>shared setup text</td><td>Rate: check</td><td>Rinse.</td></tr>'
         '</tbody></table>'
     )
     new_html = (
         '<table><tbody>'
-        '<tr><td>Alpha</td><td>shared setup text</td><td>Rate: changed1</td><td>Long notes requiring careful monitoring and administration throughout procedure.</td></tr>'
-        '<tr><td>Beta</td><td>shared setup text</td><td>Rate: changed2</td><td>Rinse.</td></tr>'
-        '<tr><td>Gamma</td><td>shared setup text</td><td>Rate: changed3</td><td>Rinse.</td></tr>'
+        '<tr><td>Alpha</td><td>shared setup text</td><td>Rate: changed1</td><td>Long notes requiring careful monitoring and administration throughout procedure.</td></tr>'  # noqa E501
+        '<tr><td>Beta</td><td>shared setup text</td><td>Rate: changed2</td><td>Rinse.</td></tr>'  # noqa E501
+        '<tr><td>Gamma</td><td>shared setup text</td><td>Rate: changed3</td><td>Rinse.</td></tr>'  # noqa E501
         '</tbody></table>'
     )
     result = diff(old_html, new_html)

--- a/htmltreediff/test_html.py
+++ b/htmltreediff/test_html.py
@@ -782,39 +782,26 @@ def test_similar_rows_not_misaligned_with_colgroup():
     """
     old_html = (
         '<table><tbody>'
-        '<tr><td>Alpha</td><td>shared setup text</td>'
-        '<td>Rate: check</td>'
-        '<td>Long notes requiring careful monitoring'
-        ' and administration throughout procedure.</td></tr>'
-        '<tr><td>Beta</td><td>shared setup text</td>'
-        '<td>Rate: check</td><td>Rinse.</td></tr>'
-        '<tr><td>Gamma</td><td>shared setup text</td>'
-        '<td>Rate: check</td><td>Rinse.</td></tr>'
+        '<tr><td>Alpha</td><td>shared setup text</td><td>Rate: check</td><td>Long notes requiring careful monitoring and administration throughout procedure.</td></tr>'  # noqa E501
+        '<tr><td>Beta</td><td>shared setup text</td><td>Rate: check</td><td>Rinse.</td></tr>'
+        '<tr><td>Gamma</td><td>shared setup text</td><td>Rate: check</td><td>Rinse.</td></tr>'
         '</tbody></table>'
     )
     new_html = (
         '<table><colgroup><col/><col/><col/><col/></colgroup><tbody>'
-        '<tr><td>Alpha</td><td>shared setup text</td>'
-        '<td>Rate: changed1</td>'
-        '<td>Long notes requiring careful monitoring'
-        ' and administration throughout procedure.</td></tr>'
-        '<tr><td>Beta</td><td>shared setup text</td>'
-        '<td>Rate: changed2</td><td>Rinse.</td></tr>'
-        '<tr><td>Gamma</td><td>shared setup text</td>'
-        '<td>Rate: changed3</td><td>Rinse.</td></tr>'
+        '<tr><td>Alpha</td><td>shared setup text</td><td>Rate: changed1</td><td>Long notes requiring careful monitoring and administration throughout procedure.</td></tr>'  # noqa E501
+        '<tr><td>Beta</td><td>shared setup text</td><td>Rate: changed2</td><td>Rinse.</td></tr>'  # noqa E501
+        '<tr><td>Gamma</td><td>shared setup text</td><td>Rate: changed3</td><td>Rinse.</td></tr>'  # noqa E501
         '</tbody></table>'
     )
-    result = diff(old_html, new_html)
-    # Row names are unchanged - should not appear in del/ins.
-    for name in ['Alpha', 'Beta', 'Gamma']:
-        assert_equal(
-            '<del>' + name not in result and '<ins>' + name not in result,
-            True,
-            'Row %s should not be misaligned: %s' % (name, result),
-        )
-    # Only the Rate column should show changes.
-    assert '<del>' in result, result
-    assert '<ins>' in result, result
+    expected = (
+        '<table><tbody>'
+        '<tr><td>Alpha</td><td>shared setup text</td><td>Rate: <del>check</del><ins>changed1</ins></td><td>Long notes requiring careful monitoring and administration throughout procedure.</td></tr>'  # noqa E501
+        '<tr><td>Beta</td><td>shared setup text</td><td>Rate: <del>check</del><ins>changed2</ins></td><td>Rinse.</td></tr>'  # noqa E501
+        '<tr><td>Gamma</td><td>shared setup text</td><td>Rate: <del>check</del><ins>changed3</ins></td><td>Rinse.</td></tr>'  # noqa E501
+        '</tbody></table>'
+    )
+    assert_equal(diff(old_html, new_html), expected)
 
 
 def test_similar_rows_not_misaligned_without_colgroup():
@@ -840,17 +827,14 @@ def test_similar_rows_not_misaligned_without_colgroup():
         '<tr><td>Gamma</td><td>shared setup text</td><td>Rate: changed3</td><td>Rinse.</td></tr>'  # noqa E501
         '</tbody></table>'
     )
-    result = diff(old_html, new_html)
-    # Row names are unchanged - should not appear in del/ins.
-    for name in ['Alpha', 'Beta', 'Gamma']:
-        assert_equal(
-            '<del>' + name not in result and '<ins>' + name not in result,
-            True,
-            'Row %s should not be misaligned: %s' % (name, result),
-        )
-    # Only the Rate column should show changes.
-    assert '<del>' in result, result
-    assert '<ins>' in result, result
+    expected = (
+        '<table><tbody>'
+        '<tr><td>Alpha</td><td>shared setup text</td><td>Rate: <del>check</del><ins>changed1</ins></td><td>Long notes requiring careful monitoring and administration throughout procedure.</td></tr>'  # noqa E501
+        '<tr><td>Beta</td><td>shared setup text</td><td>Rate: <del>check</del><ins>changed2</ins></td><td>Rinse.</td></tr>'  # noqa E501
+        '<tr><td>Gamma</td><td>shared setup text</td><td>Rate: <del>check</del><ins>changed3</ins></td><td>Rinse.</td></tr>'  # noqa E501
+        '</tbody></table>'
+    )
+    assert_equal(diff(old_html, new_html), expected)
 
 
 def test_add_class_to_empty_del_tags():

--- a/htmltreediff/test_html.py
+++ b/htmltreediff/test_html.py
@@ -639,7 +639,7 @@ def test_fix_tables():
             '''
         ),
         (
-            'tbody del and ins pair is distributed',
+            'tbody del and ins pair is internalized',
             '''
             <table>
               <del><tbody><tr><td>old data</td></tr></tbody></del>
@@ -649,6 +649,56 @@ def test_fix_tables():
             '''
             <table>
               <tbody><tr><td><del>old data</del><ins>new data</ins></td></tr></tbody>
+            </table>
+            '''
+        ),
+        (
+            'thead del and ins pair is internalized',
+            '''
+            <table>
+              <del><thead><tr><th>old header</th></tr></thead></del>
+              <ins><thead><tr><th>new header</th></tr></thead></ins>
+              <tbody><tr><td>data</td></tr></tbody>
+            </table>
+            ''',
+            '''
+            <table>
+              <thead><tr><th><del>old header</del><ins>new header</ins></th></tr></thead>
+              <tbody><tr><td>data</td></tr></tbody>
+            </table>
+            '''
+        ),
+        (
+            'tfoot del and ins pair is internalized',
+            '''
+            <table>
+              <tbody><tr><td>data</td></tr></tbody>
+              <del><tfoot><tr><td>old footer</td></tr></tfoot></del>
+              <ins><tfoot><tr><td>new footer</td></tr></tfoot></ins>
+            </table>
+            ''',
+            '''
+            <table>
+              <tbody><tr><td>data</td></tr></tbody>
+              <tfoot><tr><td><del>old footer</del><ins>new footer</ins></td></tr></tfoot>
+            </table>
+            '''
+        ),
+        (
+            'tr del and ins pair is internalized',
+            '''
+            <table>
+              <tbody>
+                <del><tr><td>old row</td></tr></del>
+                <ins><tr><td>new row</td></tr></ins>
+              </tbody>
+            </table>
+            ''',
+            '''
+            <table>
+              <tbody>
+                <tr><td><del>old row</del><ins>new row</ins></td></tr>
+              </tbody>
             </table>
             '''
         ),

--- a/htmltreediff/test_html.py
+++ b/htmltreediff/test_html.py
@@ -747,6 +747,112 @@ def test_fix_tables():
         yield test
 
 
+def test_diff_focused_on_changed_cells_when_colgroup_added():
+    old_html = (
+        '<table><tbody>'
+        '<tr><td>Alpha</td><td>unchanged</td></tr>'
+        '<tr><td>Beta</td><td>old value</td></tr>'
+        '</tbody></table>'
+    )
+    new_html = (
+        '<table><colgroup><col/><col/></colgroup><tbody>'
+        '<tr><td>Alpha</td><td>unchanged</td></tr>'
+        '<tr><td>Beta</td><td>new value</td></tr>'
+        '</tbody></table>'
+    )
+    result = diff(old_html, new_html)
+    # Table should not be entirely replaced.
+    assert '<del><table' not in result, result
+    # Unchanged content should appear without markup.
+    assert '<td>Alpha</td>' in result, result
+    assert '<td>unchanged</td>' in result, result
+    # Only the changed cell should have del/ins.
+    assert '<del>old</del>' in result, result
+    assert '<ins>new</ins>' in result, result
+
+
+def test_similar_rows_not_misaligned_with_colgroup():
+    """
+    When a colgroup is added and rows share boilerplate text, pairwise
+    fuzzy matching should align each old row to its positional counterpart
+    rather than misaligning due to non-transitive text similarity.
+
+    The text lengths here are tuned to trigger SequenceMatcher misalignment
+    in the old code path; do not shorten them.
+    """
+    old_html = (
+        '<table><tbody>'
+        '<tr><td>Alpha</td><td>shared setup text</td>'
+        '<td>Rate: check</td>'
+        '<td>Long notes requiring careful monitoring'
+        ' and administration throughout procedure.</td></tr>'
+        '<tr><td>Beta</td><td>shared setup text</td>'
+        '<td>Rate: check</td><td>Rinse.</td></tr>'
+        '<tr><td>Gamma</td><td>shared setup text</td>'
+        '<td>Rate: check</td><td>Rinse.</td></tr>'
+        '</tbody></table>'
+    )
+    new_html = (
+        '<table><colgroup><col/><col/><col/><col/></colgroup><tbody>'
+        '<tr><td>Alpha</td><td>shared setup text</td>'
+        '<td>Rate: changed1</td>'
+        '<td>Long notes requiring careful monitoring'
+        ' and administration throughout procedure.</td></tr>'
+        '<tr><td>Beta</td><td>shared setup text</td>'
+        '<td>Rate: changed2</td><td>Rinse.</td></tr>'
+        '<tr><td>Gamma</td><td>shared setup text</td>'
+        '<td>Rate: changed3</td><td>Rinse.</td></tr>'
+        '</tbody></table>'
+    )
+    result = diff(old_html, new_html)
+    # Row names are unchanged - should not appear in del/ins.
+    for name in ['Alpha', 'Beta', 'Gamma']:
+        assert_equal(
+            '<del>' + name not in result and '<ins>' + name not in result,
+            True,
+            'Row %s should not be misaligned: %s' % (name, result),
+        )
+    # Only the Rate column should show changes.
+    assert '<del>' in result, result
+    assert '<ins>' in result, result
+
+
+def test_similar_rows_not_misaligned_without_colgroup():
+    """
+    Same non-transitive fuzzy equality problem as above, but triggered
+    without a colgroup -- every row has a small change so no exact matches
+    exist and all rows go through fuzzy matching.
+
+    The text lengths here are tuned to trigger SequenceMatcher misalignment
+    in the old code path; do not shorten them.
+    """
+    old_html = (
+        '<table><tbody>'
+        '<tr><td>Alpha</td><td>shared setup text</td><td>Rate: check</td><td>Long notes requiring careful monitoring and administration throughout procedure.</td></tr>'
+        '<tr><td>Beta</td><td>shared setup text</td><td>Rate: check</td><td>Rinse.</td></tr>'
+        '<tr><td>Gamma</td><td>shared setup text</td><td>Rate: check</td><td>Rinse.</td></tr>'
+        '</tbody></table>'
+    )
+    new_html = (
+        '<table><tbody>'
+        '<tr><td>Alpha</td><td>shared setup text</td><td>Rate: changed1</td><td>Long notes requiring careful monitoring and administration throughout procedure.</td></tr>'
+        '<tr><td>Beta</td><td>shared setup text</td><td>Rate: changed2</td><td>Rinse.</td></tr>'
+        '<tr><td>Gamma</td><td>shared setup text</td><td>Rate: changed3</td><td>Rinse.</td></tr>'
+        '</tbody></table>'
+    )
+    result = diff(old_html, new_html)
+    # Row names are unchanged - should not appear in del/ins.
+    for name in ['Alpha', 'Beta', 'Gamma']:
+        assert_equal(
+            '<del>' + name not in result and '<ins>' + name not in result,
+            True,
+            'Row %s should not be misaligned: %s' % (name, result),
+        )
+    # Only the Rate column should show changes.
+    assert '<del>' in result, result
+    assert '<ins>' in result, result
+
+
 def test_add_class_to_empty_del_tags():
     cases = [
         (

--- a/htmltreediff/test_util.py
+++ b/htmltreediff/test_util.py
@@ -1,11 +1,15 @@
+from unittest.mock import patch
+
 from htmltreediff.diff_core import Differ
 from htmltreediff.edit_script_runner import EditScriptRunner
 from htmltreediff.changes import (
     split_text_nodes,
     sort_nodes,
 )
+from htmltreediff.text import WordMatcher
 from htmltreediff.util import (
     attribute_dict,
+    check_text_similarity,
     minidom_tostring,
     node_compare,
     parse_minidom,
@@ -133,3 +137,27 @@ def test_node_compare():
     ins_node = list(walk_dom(parse_minidom('<ins/>')))[-1]
     assert -1 == node_compare(del_node, ins_node)
     assert 1 == node_compare(ins_node, del_node)
+
+
+def _uses_autojunk(html):
+    dom = parse_minidom(html)
+    node = dom.documentElement.firstChild
+    captured = []
+    original_init = WordMatcher.__init__
+
+    def spy_init(self, **kwargs):
+        captured.append(kwargs.get('autojunk', True))
+        original_init(self, **kwargs)
+
+    with patch.object(WordMatcher, '__init__', spy_init):
+        check_text_similarity(node, node, cutoff=0.4)
+
+    return any(captured)
+
+
+def test_check_text_similarity_autojunk_disabled_for_table_element():
+    assert _uses_autojunk('<tbody><tr><td>Some cell text</td></tr></tbody>') is False
+
+
+def test_check_text_similarity_autojunk_enabled_for_non_table_element():
+    assert _uses_autojunk('<p>Some text here</p>') is True

--- a/htmltreediff/text.py
+++ b/htmltreediff/text.py
@@ -125,12 +125,12 @@ class WordMatcher(SequenceMatcher):
     WordMatcher is a SequenceMatcher that can measure the similarity of
     sequences of words based on the total length of matching words.
     """
-    def __init__(self, isjunk=is_text_junk, a=None, b=None):
+    def __init__(self, isjunk=is_text_junk, a=None, b=None, autojunk=True):
         if a is None:
             a = []
         if b is None:
             b = []
-        SequenceMatcher.__init__(self, isjunk, a, b)
+        SequenceMatcher.__init__(self, isjunk, a, b, autojunk=autojunk)
 
     def text_ratio(self):
         """Return a measure of the sequences' word similarity (float in [0,1]).

--- a/htmltreediff/util.py
+++ b/htmltreediff/util.py
@@ -358,12 +358,25 @@ def walk_dom(dom, elements_only=False):
     return walk(dom)
 
 
+TABLE_ELEMENT_TAGS = {
+    'table', 'thead', 'tbody', 'tfoot', 'tr', 'td', 'th', 'caption', 'colgroup', 'col',
+}
+
+
+def dom_node_in_table_context(node):
+    return is_element(node) and node.tagName.lower() in TABLE_ELEMENT_TAGS
+
+
 def check_text_similarity(a_dom, b_dom, cutoff):
     """Check whether two dom trees have similar text or not."""
     a_words = list(tree_words(a_dom))
     b_words = list(tree_words(b_dom))
 
-    sm = WordMatcher(a=a_words, b=b_words)
+    # disabling autojunk gives a better diff at the cost of it potentially being slower,
+    # so limit to only tables
+    autojunk = not dom_node_in_table_context(a_dom)
+
+    sm = WordMatcher(a=a_words, b=b_words, autojunk=autojunk)
     if sm.text_ratio() >= cutoff:
         return True
     return False

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def get_requirements(path):
 
 setup(
     name="html-tree-diff",
-    version="0.3.0",
+    version="0.3.1",
     description="Structure-aware diff for html and xml documents",
     author="Christian Oudard",
     author_email="christian.oudard@gmail.com",


### PR DESCRIPTION
Include the `tbody`/`thead`/`tfoot` tags in the `fix_tables` clean up to move the `ins` and `del` tags inside the `td` and `th` tags. This prevents the complete removal of the table contents in these cases.